### PR TITLE
Fix Compilation

### DIFF
--- a/PvPManager/pom.xml
+++ b/PvPManager/pom.xml
@@ -16,21 +16,17 @@
 			<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
 		</repository>
 		<repository>
-			<id>vault-repo</id>
-			<url>http://nexus.hc.to/content/repositories/pub_releases</url>
-		</repository>
-		<repository>
 			<id>placeholderapi</id>
-			<url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+			<url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
 		</repository>
 
-		<!-- WorldGuard -->
+		<!-- WorldGuard and CommandBook -->
 		<repository>
 			<id>sk89q-repo</id>
-			<url>http://maven.sk89q.com/repo/</url>
+			<url>https://maven.enginehub.org/repo/</url>
 		</repository>
 
-		<!-- SimpleClans -->
+		<!-- SimpleClans and Vault -->
 		<repository>
 			<id>jitpack.io</id>
 			<url>https://jitpack.io</url>
@@ -45,7 +41,7 @@
 		<!-- LibsDisguises -->
 		<repository>
 			<id>md_5-public</id>
-			<url>http://repo.md-5.net/content/groups/public/</url>
+			<url>https://repo.md-5.net/content/groups/public/</url>
 		</repository>
 	</repositories>
 
@@ -221,9 +217,9 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>net.milkbowl.vault</groupId>
-			<artifactId>Vault</artifactId>
-			<version>1.7.3</version>
+			<groupId>com.github.MilkBowl</groupId>
+			<artifactId>VaultAPI</artifactId>
+			<version>1.7</version>
 			<scope>provided</scope>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
When trying to compile the plugin, several errors appear when obtaining the dependencies.
`[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for PvPManager-parent 3.8-SNAPSHOT:
[INFO]
[INFO] PvPManager-parent .................................. SUCCESS [  0.204 s]
[INFO] PvPManager ......................................... FAILURE [  3.029 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.509 s
[INFO] Finished at: 2021-05-27T19:38:42-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project PvPManager: Could not resolve dependencies for project me.NoChance.PvPManager:PvPManager:jar:3.8-SNAPSHOT: Failed to collect dependencies at com.sk89q:commandbook:jar:2.5-SNAPSHOT: Failed to read artifact descriptor for com.sk89q:commandbook:jar:2.5-SNAPSHOT: Could not transfer artifact com.sk89q:commandbook:pom:2.5-SNAPSHOT from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [vault-repo (http://nexus.hc.to/content/repositories/pub_releases, default, releases+snapshots), placeholderapi (http://repo.extendedclip.com/content/repositories/placeholderapi/, default, releases+snapshots), sk89q-repo (http://maven.sk89q.com/repo/, default, releases+snapshots), md_5-public (http://repo.md-5.net/content/groups/public/, default, releases+snapshots)] -> [Help 1]`
Here I fix those problems with getting dependencies.