### PR TITLE
fix worldguard region override

### DIFF
--- a/PvPManager/pom.xml
+++ b/PvPManager/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>me.NoChance.PvPManager</groupId>
 		<artifactId>PvPManager-parent</artifactId>
-		<version>3.10.0</version>
+		<version>3.10.1</version>
 	</parent>
 
 	<artifactId>PvPManager</artifactId>

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Managers/PlayerHandler.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Managers/PlayerHandler.java
@@ -58,13 +58,13 @@ public class PlayerHandler {
 		if (attacked.isNewbie() || attacker.isNewbie())
 			return CancelResult.NEWBIE.setAttackerCaused(attacker.isNewbie());
 		if (!attacker.hasPvPEnabled() || !attacked.hasPvPEnabled()) {
-			if (worldguard != null && worldguard.hasAllowPvPFlag(defender)
-			        && (Settings.isWorldguardOverrides() || worldguard.containsRegionsAt(defender.getLocation(), Settings.getWorldguardOverridesList()))) {
+			if (worldguard != null && (Settings.isWorldguardOverrides() && worldguard.hasAllowPvPFlag(defender)
+			        || worldguard.containsRegionsAt(defender.getLocation(), Settings.getWorldguardOverridesList()))) {
 				if (!attacker.hasPvPEnabled()) {
 					attacker.setPvP(true);
 					attacker.message(Messages.getPvpForceEnabledWG());
 				}
-				if (!attacked.hasPvPEnabled()){
+				if (!attacked.hasPvPEnabled()) {
 					attacked.setPvP(true);
 					attacked.message(Messages.getPvpForceEnabledWG());
 				}

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Managers/PlayerHandler.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Managers/PlayerHandler.java
@@ -58,12 +58,16 @@ public class PlayerHandler {
 		if (attacked.isNewbie() || attacker.isNewbie())
 			return CancelResult.NEWBIE.setAttackerCaused(attacker.isNewbie());
 		if (!attacker.hasPvPEnabled() || !attacked.hasPvPEnabled()) {
-			if (Settings.isWorldguardOverrides() && worldguard != null
-			        && (worldguard.containsRegionsAt(defender.getLocation(), Settings.getWorldguardOverridesList()) || worldguard.hasAllowPvPFlag(defender))) {
-				attacker.setPvP(true);
-				attacked.setPvP(true);
-				attacker.message(Messages.getPvpForceEnabledWG());
-				attacked.message(Messages.getPvpForceEnabledWG());
+			if (worldguard != null && worldguard.hasAllowPvPFlag(defender)
+			        && (Settings.isWorldguardOverrides() || worldguard.containsRegionsAt(defender.getLocation(), Settings.getWorldguardOverridesList()))) {
+				if (!attacker.hasPvPEnabled()) {
+					attacker.setPvP(true);
+					attacker.message(Messages.getPvpForceEnabledWG());
+				}
+				if (!attacked.hasPvPEnabled()){
+					attacked.setPvP(true);
+					attacked.message(Messages.getPvpForceEnabledWG());
+				}
 			} else if (dependencyManager.shouldDisableProtection(damager, defender))
 				return CancelResult.FAIL;
 			return CancelResult.PVPDISABLED.setAttackerCaused(!attacker.hasPvPEnabled());

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Settings/Messages.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Settings/Messages.java
@@ -191,7 +191,7 @@ public class Messages {
 		errorPlayerNotFound = getString("Error_Player_Not_Found");
 		respawnProtectionSelf = getString("Respawn_Protection");
 		respawnProtectionOther = getString("Respawn_Protection_Other");
-		pvpForceEnabledWG = getString("PvP_Force_Enabled_WorlGuard");
+		pvpForceEnabledWG = getString("PvP_Force_Enabled_WorldGuard");
 		tagRemaining = getString("Tag_Remaining");
 	}
 

--- a/PvPManager/src/main/resources/config.yml
+++ b/PvPManager/src/main/resources/config.yml
@@ -158,9 +158,8 @@ Player Kills:
 # Commands -> Command list to execute on PvP toggle, use '%p' for player name
 # Force On Change World -> Force player PvP to default when changing world, useful if there are worlds
 # where players don't have permission to use /pvp
-# WorldGuard Overrides -> Players can still be damaged in PvP in areas with WG's pvp flag set to allow
-# WorldGuard Overrides Region List -> If instead of using the pvp flag, you want to define which regions get pvp force enabled
-# If you want to force enable pvp in all regions with pvp flag ALLOW then just leave the list empty or with example
+# WorldGuard Overrides -> PvP Toggle is forcibly enabled on an attack in all regions with WG's pvp flag set to allow
+# WorldGuard overrides region list -> PvP Toggle is forcibly enabled on an attack in the listed regions, but only if WG's pvp flag is set to allow in this region
 PvP Toggle:
   Cooldown: 15
   NameTags:

--- a/PvPManager/src/main/resources/config.yml
+++ b/PvPManager/src/main/resources/config.yml
@@ -159,7 +159,7 @@ Player Kills:
 # Force On Change World -> Force player PvP to default when changing world, useful if there are worlds
 # where players don't have permission to use /pvp
 # WorldGuard Overrides -> PvP Toggle is forcibly enabled on an attack in all regions with WG's pvp flag set to allow
-# WorldGuard overrides region list -> PvP Toggle is forcibly enabled on an attack in the listed regions, but only if WG's pvp flag is set to allow in this region
+# WorldGuard overrides region list -> PvP Toggle is forcibly enabled on an attack in the listed regions, regardless of the WG's pvp flag
 PvP Toggle:
   Cooldown: 15
   NameTags:

--- a/PvPManager/src/main/resources/locale/messages.properties
+++ b/PvPManager/src/main/resources/locale/messages.properties
@@ -14,7 +14,7 @@ Self_Status_Disabled = &6[&8PvPManager&6] &6You have PvP disabled
 Self_Status_Enabled = &6[&8PvPManager&6] &6You have PvP enabled
 Attack_Denied_You = &6[&8PvPManager&6] &4You have PvP disabled!
 Attack_Denied_Other = &6[&8PvPManager&6] &4%p has PvP disabled!
-PvP_Force_Enabled_WorlGuard = &6[&8PvPManager&6] &cPvP was force enabled because you are inside a PvP region
+PvP_Force_Enabled_WorldGuard = &6[&8PvPManager&6] &cPvP force enabled because you are inside a PvP region
 
 # Combat Tag
 Tagged_Attacker = &6[&8PvPManager&6] &7You tagged&f %p&7! Do not log out or you will be punished!

--- a/PvPManager/src/main/resources/locale/messages.properties
+++ b/PvPManager/src/main/resources/locale/messages.properties
@@ -14,7 +14,7 @@ Self_Status_Disabled = &6[&8PvPManager&6] &6You have PvP disabled
 Self_Status_Enabled = &6[&8PvPManager&6] &6You have PvP enabled
 Attack_Denied_You = &6[&8PvPManager&6] &4You have PvP disabled!
 Attack_Denied_Other = &6[&8PvPManager&6] &4%p has PvP disabled!
-PvP_Force_Enabled_WorlGuard = &cYour PvP was enabled because you entered a PvP allowed region
+PvP_Force_Enabled_WorlGuard = &6[&8PvPManager&6] &cPvP was force enabled because you are inside a PvP region
 
 # Combat Tag
 Tagged_Attacker = &6[&8PvPManager&6] &7You tagged&f %p&7! Do not log out or you will be punished!

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>me.NoChance.PvPManager</groupId>
 	<artifactId>PvPManager-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>3.10.0</version>
+	<version>3.10.1</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This pull fixes worldguard override.
It was impossible to use override only for specific regions. The requirement to have Wordguarde "Override enable" in the code makes the region list useless since the "Override enable" and hasAllowPvPFlag always overrule the region list.

After this pull PvP is forcibly enables under two conditions:
- WorldGuard Overrides and pvp enabled in this wg region
 or
- Region in the regions override list and pvp is enabled in this wg region.

This pull also silence the pvp enabled message for players where pvp was already enabled.
