### PR TITLE
Ender Pearl Cooldown while in tagged.

### DIFF
--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener.java
@@ -1,20 +1,16 @@
 package me.NoChance.PvPManager.Listeners;
 
-import me.NoChance.PvPManager.PvPManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerFishEvent;
@@ -139,21 +135,6 @@ public class PlayerListener implements Listener {
 		}
 
 		ph.handlePlayerDrops(event, player, killer);
-	}
-
-	@EventHandler
-	public void onProjectileLaunchEvent(ProjectileLaunchEvent event) {
-		Projectile entity = event.getEntity();
-		if (!(entity.getShooter() instanceof Player) || entity.getType() != EntityType.ENDER_PEARL) {
-			return;
-		}
-
-		Player player = (Player) entity.getShooter();
-		PvPlayer pvPlayer = ph.get(player);
-
-		if (pvPlayer.isInCombat()) {
-			Bukkit.getScheduler().runTask(PvPManager.getInstance(), () -> player.setCooldown(Material.ENDER_PEARL, Settings.getEnderPearlCooldown() * 20));
-		}
 	}
 
 	@EventHandler

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener.java
@@ -1,16 +1,20 @@
 package me.NoChance.PvPManager.Listeners;
 
+import me.NoChance.PvPManager.PvPManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerFishEvent;
@@ -135,6 +139,21 @@ public class PlayerListener implements Listener {
 		}
 
 		ph.handlePlayerDrops(event, player, killer);
+	}
+
+	@EventHandler
+	public void onProjectileLaunchEvent(ProjectileLaunchEvent event) {
+		Projectile entity = event.getEntity();
+		if (!(entity.getShooter() instanceof Player) || entity.getType() != EntityType.ENDER_PEARL) {
+			return;
+		}
+
+		Player player = (Player) entity.getShooter();
+		PvPlayer pvPlayer = ph.get(player);
+
+		if (pvPlayer.isInCombat()) {
+			Bukkit.getScheduler().runTask(PvPManager.getInstance(), () -> player.setCooldown(Material.ENDER_PEARL, Settings.getEnderPearlCooldown() * 20));
+		}
 	}
 
 	@EventHandler

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener1_11.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener1_11.java
@@ -1,0 +1,40 @@
+package me.NoChance.PvPManager.Listeners;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.projectiles.ProjectileSource;
+
+import me.NoChance.PvPManager.PvPlayer;
+import me.NoChance.PvPManager.Managers.PlayerHandler;
+import me.NoChance.PvPManager.Settings.Settings;
+
+public class PlayerListener1_11 implements Listener {
+
+	private final PlayerHandler playerHandler;
+
+	public PlayerListener1_11(final PlayerHandler ph) {
+		this.playerHandler = ph;
+	}
+
+	@EventHandler
+	public void onProjectileLaunchEvent(final ProjectileLaunchEvent event) {
+		final Projectile entity = event.getEntity();
+		final ProjectileSource shooter = entity.getShooter();
+		if (entity.getType() != EntityType.ENDER_PEARL || !(shooter instanceof Player))
+			return;
+
+		final Player player = (Player) shooter;
+		final PvPlayer pvPlayer = playerHandler.get(player);
+
+		if (pvPlayer.isInCombat()) {
+			Bukkit.getScheduler().runTask(playerHandler.getPlugin(), () -> player.setCooldown(Material.ENDER_PEARL, Settings.getEnderPearlCooldown() * 20));
+		}
+	}
+
+}

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/PvPManager.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/PvPManager.java
@@ -24,6 +24,7 @@ import me.NoChance.PvPManager.Libraries.Updater.Updater.UpdateType;
 import me.NoChance.PvPManager.Listeners.EntityListener;
 import me.NoChance.PvPManager.Listeners.EntityListener1_9;
 import me.NoChance.PvPManager.Listeners.PlayerListener;
+import me.NoChance.PvPManager.Listeners.PlayerListener1_11;
 import me.NoChance.PvPManager.Managers.ConfigManager;
 import me.NoChance.PvPManager.Managers.DependencyManager;
 import me.NoChance.PvPManager.Managers.DisplayManager;
@@ -76,6 +77,9 @@ public class PvPManager extends JavaPlugin {
 		}
 		entityListener = new EntityListener(playerHandler);
 		registerListener(entityListener);
+		if (CombatUtils.isVersionAtLeast(Settings.getMinecraftVersion(), "1.11.2")) {
+			registerListener(new PlayerListener1_11(playerHandler));
+		}
 		registerListener(new PlayerListener(playerHandler));
 		dependencyManager.startListeners(this);
 	}

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Settings/Settings.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Settings/Settings.java
@@ -89,6 +89,7 @@ public final class Settings {
 	private static boolean borderHoppingResetCombatTag;
 	private static boolean worldguardOverrides;
 	private static Set<String> worldguardOverridesList;
+	private static int enderPearlCooldown;
 	private static boolean glowingInCombat;
 	private static boolean selfTag;
 	private static boolean blockInteractInCombat;
@@ -212,6 +213,7 @@ public final class Settings {
 		forcePvPOnWorldChange = PVPTOGGLE.getBoolean("Force On Change World", false);
 		worldguardOverrides = PVPTOGGLE.getBoolean("WorldGuard Overrides", true);
 		worldguardOverridesList = new HashSet<>(getList(PVPTOGGLE.getStringList("WorldGuard Overrides Region List")));
+		enderPearlCooldown = PVPTOGGLE.getInt("Ender Pearl Cooldown");
 
 		simpleClansNoPvPInWar = Hook.SIMPLECLANS.getPlugin() == null ? false : PLUGINHOOKS.getBoolean("SimpleClans.No Protection In War", true);
 
@@ -578,6 +580,10 @@ public final class Settings {
 
 	public static boolean isWorldguardOverrides() {
 		return worldguardOverrides;
+	}
+
+	public static int getEnderPearlCooldown() {
+		return enderPearlCooldown;
 	}
 
 	public static boolean isGlowingInCombat() {

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Settings/Settings.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Settings/Settings.java
@@ -213,7 +213,7 @@ public final class Settings {
 		forcePvPOnWorldChange = PVPTOGGLE.getBoolean("Force On Change World", false);
 		worldguardOverrides = PVPTOGGLE.getBoolean("WorldGuard Overrides", true);
 		worldguardOverridesList = new HashSet<>(getList(PVPTOGGLE.getStringList("WorldGuard Overrides Region List")));
-		enderPearlCooldown = PVPTOGGLE.getInt("Ender Pearl Cooldown");
+		enderPearlCooldown = TAGGEDCOMBAT.getInt("EnderPearl Cooldown");
 
 		simpleClansNoPvPInWar = Hook.SIMPLECLANS.getPlugin() == null ? false : PLUGINHOOKS.getBoolean("SimpleClans.No Protection In War", true);
 

--- a/PvPManager/src/main/resources/config.yml
+++ b/PvPManager/src/main/resources/config.yml
@@ -179,6 +179,7 @@ PvP Toggle:
   WorldGuard Overrides: true
   WorldGuard Overrides Region List:
     - 'example'
+  Ender Pearl Cooldown: 15
 
 # Section to configure interactions with other plugins
 Plugin Hooks:

--- a/PvPManager/src/main/resources/config.yml
+++ b/PvPManager/src/main/resources/config.yml
@@ -110,6 +110,7 @@ Tagged In Combat:
         Armor: true
     Commands On PvPLog:
       - 'announce &6[&8PvPManager&6]&c %p tried to escape combat and died!'
+  EnderPearl Cooldown: 15
 
 # Should new players on your server be protected from PvP (If they want to PvP they can use /newbie disable)
 Newbie Protection:
@@ -179,7 +180,6 @@ PvP Toggle:
   WorldGuard Overrides: true
   WorldGuard Overrides Region List:
     - 'example'
-  Ender Pearl Cooldown: 15
 
 # Section to configure interactions with other plugins
 Plugin Hooks:


### PR DESCRIPTION
Instead of blocking ender pearls while players are in combat, I prefer allowing them to use them but with a cooldown.

It's made to show the cooldown in the hotbar, simulating the default minecraft ender pearl cooldown.