### PR TITLE
Fix 'Cannot have negative cooldown'

### DIFF
--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener1_11.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener1_11.java
@@ -26,7 +26,7 @@ public class PlayerListener1_11 implements Listener {
 	public void onProjectileLaunchEvent(final ProjectileLaunchEvent event) {
 		final Projectile entity = event.getEntity();
 		final ProjectileSource shooter = entity.getShooter();
-		if (entity.getType() != EntityType.ENDER_PEARL || !(shooter instanceof Player))
+		if (Settings.getEnderPearlCooldown() < 0 || entity.getType() != EntityType.ENDER_PEARL || !(shooter instanceof Player))
 			return;
 
 		final Player player = (Player) shooter;

--- a/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener1_11.java
+++ b/PvPManager/src/main/java/me/NoChance/PvPManager/Listeners/PlayerListener1_11.java
@@ -26,7 +26,7 @@ public class PlayerListener1_11 implements Listener {
 	public void onProjectileLaunchEvent(final ProjectileLaunchEvent event) {
 		final Projectile entity = event.getEntity();
 		final ProjectileSource shooter = entity.getShooter();
-		if (Settings.getEnderPearlCooldown() < 0 || entity.getType() != EntityType.ENDER_PEARL || !(shooter instanceof Player))
+		if (Settings.getEnderPearlCooldown() <= 0 || entity.getType() != EntityType.ENDER_PEARL || !(shooter instanceof Player))
 			return;
 
 		final Player player = (Player) shooter;


### PR DESCRIPTION
* Fix 'Cannot have negative cooldown'
* If you don't want the EnderPearl custom cooldown, you can disable it by setting `EnderPearl Cooldown` to -1.