### PR TITLE
fix: players that were allowed to fly before being tagged were not after being untagged

### DIFF
--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Listeners/EntityListener.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Listeners/EntityListener.java
@@ -131,6 +131,10 @@ public class EntityListener implements Listener {
 		if (Settings.isPvpBlood()) {
 			defender.getWorld().playEffect(defender.getLocation(), Effect.STEP_SOUND, Material.REDSTONE_BLOCK);
 		}
+
+		updateFlightAllowedState(pvpDefender);
+		updateFlightAllowedState(pvpAttacker);
+
 		disableActions(attacker, defender, pvpAttacker, pvpDefender);
 		if (Settings.isInCombatEnabled()) {
 			if (Settings.borderHoppingVulnerable() && wg != null && !Settings.borderHoppingResetCombatTag() && wg.hasDenyPvPFlag(attacker)
@@ -140,6 +144,11 @@ public class EntityListener implements Listener {
 			pvpAttacker.setTagged(true, pvpDefender);
 			pvpDefender.setTagged(false, pvpAttacker);
 		}
+	}
+
+	private void updateFlightAllowedState(PvPlayer player) {
+		if (player.isInCombat()) return;
+		player.setWasAllowedFlight(player.getPlayer().getAllowFlight());
 	}
 
 	private void disableActions(final Player attacker, final Player defender, final PvPlayer pvpAttacker, final PvPlayer pvpDefender) {

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Player/BasePlayer.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Player/BasePlayer.java
@@ -19,6 +19,7 @@ public abstract class BasePlayer {
 	private CombatWorld combatWorld;
 	private long actionBarCooldown;
 	private String lastActionBarMessage;
+	private boolean wasAllowedFlight;
 
 	protected BasePlayer(final Player player) {
 		this.player = player;
@@ -99,4 +100,11 @@ public abstract class BasePlayer {
 		return "PvPlayer[" + getName() + ", " + uuid + "]";
 	}
 
+	public boolean getWasAllowedFlight() {
+		return wasAllowedFlight;
+	}
+
+	public void setWasAllowedFlight(final boolean wasAllowedFlight) {
+		this.wasAllowedFlight = wasAllowedFlight;
+	}
 }

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/PvPlayer.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/PvPlayer.java
@@ -209,6 +209,7 @@ public class PvPlayer extends EcoPlayer {
 
 		this.lastHitters.clear();
 		this.tagged = false;
+		getPlayer().setAllowFlight(getWasAllowedFlight());
 	}
 
 	public final void setPvP(final boolean pvpState) {


### PR DESCRIPTION
### Description
When flying is disabled during PvP in the configuration, a player who was allowed to fly before being tagged does not have their flight status restored after they are untagged.

- [X] I tested these changes or am certain they have no issues
- [X] I accept that my changes may also be merged into the premium version of PvPManager