### PR TITLE
Add HuskTowns and HuskClaims support

### DIFF
--- a/pvpmanager/pom.xml
+++ b/pvpmanager/pom.xml
@@ -70,6 +70,12 @@
 			<url>https://repo.glaremasters.me/repository/towny/</url>
 		</repository>
 
+		<!-- william278 (Husk) -->
+		<repository>
+			<id>william278.net</id>
+			<url>https://repo.william278.net/releases</url>
+		</repository>
+
 	</repositories>
 
 	<build>
@@ -204,6 +210,23 @@
 			<groupId>com.palmergames.bukkit.towny</groupId>
 			<artifactId>towny</artifactId>
 			<version>0.101.1.5</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- HuskClaims -->
+		<dependency>
+			<groupId>net.william278.huskclaims</groupId>
+			<artifactId>huskclaims-bukkit</artifactId>
+			<version>1.5.2</version>
+			<scope>provided</scope>
+		</dependency>
+
+
+		<!-- HuskTowns -->
+		<dependency>
+			<groupId>net.william278.husktowns</groupId>
+			<artifactId>husktowns-bukkit</artifactId>
+			<version>3.1.2</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Dependencies/Hook.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Dependencies/Hook.java
@@ -19,6 +19,8 @@ public enum Hook {
 	PLACEHOLDERAPI("PlaceholderAPI"),
 	LIBSDISGUISES("LibsDisguises"),
 	TOWNY("Towny"),
+	HUSKTOWNS("HuskTowns"),
+	HUSKCLAIMS("HuskClaims"),
 	KINGDOMSX("Kingdoms");
 
 	@NotNull

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Dependencies/Hooks/HuskClaimsHook.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Dependencies/Hooks/HuskClaimsHook.java
@@ -12,23 +12,13 @@ import net.william278.huskclaims.libraries.cloplib.operation.OperationTypeRegist
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
-public class HuskClaimsHook extends BaseDependency implements ForceToggleDependency, RegionDependency {
+public class HuskClaimsHook extends BaseDependency implements RegionDependency {
 
 	private final BukkitHuskClaimsAPI huskClaimsAPI;
 
 	public HuskClaimsHook(final Hook hook) {
 		super(hook);
 		huskClaimsAPI = BukkitHuskClaimsAPI.getInstance();
-	}
-
-	@Override
-	public boolean shouldDisable(final Player player) {
-		return false;
-	}
-
-	@Override
-	public boolean shouldDisable(final Player attacker, final Player defender, final CancelResult reason) {
-		return shouldDisable(attacker) && shouldDisable(defender);
 	}
 
 	@Override

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Dependencies/Hooks/HuskClaimsHook.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Dependencies/Hooks/HuskClaimsHook.java
@@ -1,0 +1,45 @@
+package me.NoChance.PvPManager.Dependencies.Hooks;
+
+import me.NoChance.PvPManager.Dependencies.BaseDependency;
+import me.NoChance.PvPManager.Dependencies.ForceToggleDependency;
+import me.NoChance.PvPManager.Dependencies.Hook;
+import me.NoChance.PvPManager.Dependencies.RegionDependency;
+import me.NoChance.PvPManager.Player.CancelResult;
+import net.william278.huskclaims.api.BukkitHuskClaimsAPI;
+import net.william278.huskclaims.libraries.cloplib.operation.Operation;
+import net.william278.huskclaims.libraries.cloplib.operation.OperationType;
+import net.william278.huskclaims.libraries.cloplib.operation.OperationTypeRegistry;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class HuskClaimsHook extends BaseDependency implements ForceToggleDependency, RegionDependency {
+
+	private final BukkitHuskClaimsAPI huskClaimsAPI;
+
+	public HuskClaimsHook(final Hook hook) {
+		super(hook);
+		huskClaimsAPI = BukkitHuskClaimsAPI.getInstance();
+	}
+
+	@Override
+	public boolean shouldDisable(final Player player) {
+		return false;
+	}
+
+	@Override
+	public boolean shouldDisable(final Player attacker, final Player defender, final CancelResult reason) {
+		return shouldDisable(attacker) && shouldDisable(defender);
+	}
+
+	@Override
+	public boolean canAttackAt(final Player player, final Location location) {
+		  final OperationTypeRegistry reg = huskClaimsAPI.getOperationTypeRegistry();
+		  final boolean cancelled = reg.getHandler().cancelOperation(Operation.of(
+				OperationType.PLAYER_DAMAGE_PLAYER,
+				huskClaimsAPI.getPosition(location)
+		  ));
+
+		  return !cancelled;
+	}
+
+}

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Dependencies/Hooks/HuskTownsHook.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Dependencies/Hooks/HuskTownsHook.java
@@ -1,0 +1,59 @@
+package me.NoChance.PvPManager.Dependencies.Hooks;
+
+import net.william278.husktowns.api.BukkitHuskTownsAPI;
+import net.william278.husktowns.libraries.cloplib.operation.Operation;
+import net.william278.husktowns.libraries.cloplib.operation.OperationTypeRegistry;
+import net.william278.husktowns.town.Member;
+import net.william278.husktowns.town.Town;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import net.william278.husktowns.user.OnlineUser;
+import net.william278.husktowns.libraries.cloplib.operation.OperationType;
+
+import me.NoChance.PvPManager.Dependencies.BaseDependency;
+import me.NoChance.PvPManager.Dependencies.Hook;
+import me.NoChance.PvPManager.Dependencies.RegionDependency;
+import me.NoChance.PvPManager.Player.CancelResult;
+import me.NoChance.PvPManager.Dependencies.ForceToggleDependency;
+
+import java.util.Optional;
+
+public class HuskTownsHook extends BaseDependency implements ForceToggleDependency, RegionDependency {
+
+	private final BukkitHuskTownsAPI huskTownsAPI;
+
+	public HuskTownsHook(final Hook hook) {
+		super(hook);
+		huskTownsAPI = BukkitHuskTownsAPI.getInstance();
+	}
+
+	@Override
+	public boolean shouldDisable(final Player player) {
+		OnlineUser user = huskTownsAPI.getOnlineUser(player);
+		Optional<Member> member = huskTownsAPI.getUserTown(user);
+
+		if (!member.isPresent()) {
+			return false;
+		}
+
+		Town town = member.get().town();
+		return town.getCurrentWar().isPresent();
+	}
+
+	@Override
+	public boolean shouldDisable(final Player attacker, final Player defender, final CancelResult reason) {
+		return shouldDisable(attacker) && shouldDisable(defender);
+	}
+
+	@Override
+	public boolean canAttackAt(final Player player, final Location location) {
+		  final OperationTypeRegistry reg = huskTownsAPI.getOperationTypeRegistry();
+		  final boolean cancelled = reg.getHandler().cancelOperation(Operation.of(
+				OperationType.PLAYER_DAMAGE_PLAYER,
+				huskTownsAPI.getPosition(location)
+		  ));
+
+		  return !cancelled;
+	}
+
+}

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Managers/DependencyManager.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Managers/DependencyManager.java
@@ -21,18 +21,11 @@ import me.NoChance.PvPManager.Dependencies.DependencyException;
 import me.NoChance.PvPManager.Dependencies.DisguiseDependency;
 import me.NoChance.PvPManager.Dependencies.GodDependency;
 import me.NoChance.PvPManager.Dependencies.Hook;
+import me.NoChance.PvPManager.Dependencies.Hooks.*;
 import me.NoChance.PvPManager.Dependencies.GroupDependency;
 import me.NoChance.PvPManager.Dependencies.RegionDependency;
 import me.NoChance.PvPManager.Dependencies.ForceToggleDependency;
 import me.NoChance.PvPManager.Dependencies.WorldGuardHook;
-import me.NoChance.PvPManager.Dependencies.Hooks.EssentialsHook;
-import me.NoChance.PvPManager.Dependencies.Hooks.KingdomsXHook;
-import me.NoChance.PvPManager.Dependencies.Hooks.LibsDisguisesHook;
-import me.NoChance.PvPManager.Dependencies.Hooks.PlaceHolderAPIHook;
-import me.NoChance.PvPManager.Dependencies.Hooks.SimpleClansHook;
-import me.NoChance.PvPManager.Dependencies.Hooks.TownyHook;
-import me.NoChance.PvPManager.Dependencies.Hooks.VaultHook;
-import me.NoChance.PvPManager.Dependencies.Hooks.WorldGuardModernHook;
 import me.NoChance.PvPManager.Listeners.MoveListener;
 import me.NoChance.PvPManager.Listeners.MoveListener1_9;
 import me.NoChance.PvPManager.Player.CancelResult;
@@ -151,6 +144,12 @@ public class DependencyManager {
 			break;
 		case TOWNY:
 			registerDependency(new TownyHook(hook));
+			break;
+		case HUSKTOWNS:
+			registerDependency(new HuskTownsHook(hook));
+			break;
+		case HUSKCLAIMS:
+			registerDependency(new HuskClaimsHook(hook));
 			break;
 		case KINGDOMSX:
 			registerDependency(new KingdomsXHook(hook));

--- a/pvpmanager/src/main/resources/config.yml
+++ b/pvpmanager/src/main/resources/config.yml
@@ -239,7 +239,8 @@ Plugin Hooks:
     # Essentially only pushes back if a town is peaceful, it ignores if the town PvP is on or off, can be useful to prevent traps
     Pushback on Peaceful: false
   HuskTowns:
-  HuskClaims:
+    # Disable PvP and newbie protection if the players are in a siege war
+    No Protection In War: true
   CooldownsX:
     # Change this into the cooldown id for enderpearls in CooldownsX, by default they have it as exampleOne in cooldowns.yml
     # If setup correctly PvPManager will use a different cooldown while in combat and then revert back to CooldownsX

--- a/pvpmanager/src/main/resources/config.yml
+++ b/pvpmanager/src/main/resources/config.yml
@@ -238,6 +238,8 @@ Plugin Hooks:
     No Protection In War: true
     # Essentially only pushes back if a town is peaceful, it ignores if the town PvP is on or off, can be useful to prevent traps
     Pushback on Peaceful: false
+  HuskTowns:
+  HuskClaims:
   CooldownsX:
     # Change this into the cooldown id for enderpearls in CooldownsX, by default they have it as exampleOne in cooldowns.yml
     # If setup correctly PvPManager will use a different cooldown while in combat and then revert back to CooldownsX

--- a/pvpmanager/src/main/resources/plugin.yml
+++ b/pvpmanager/src/main/resources/plugin.yml
@@ -16,6 +16,8 @@ softdepend:
   - Essentials
   - PlaceholderAPI
   - Towny
+  - HuskTowns
+  - HuskClaims
   - Kingdoms
   - TAB
 


### PR DESCRIPTION
### Description
Add support for [HuskTowns](https://www.spigotmc.org/resources/husktowns-1-17-1-21-towny-style-claims-customizable-easy-to-use-works-cross-server.92672/) and [HuskClaims](https://www.spigotmc.org/resources/huskclaims-1-17-1-21-modern-golden-shovel-land-claiming-fully-cross-server-compatible.114467/)

- [x] I tested these changes or am certain they have no issues
- [x] I accept that my changes may also be merged into the premium version of PvPManager
