### PR TITLE
Add combat restriction for entering Residence-protected areas

### DIFF
--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Listeners/ResidenceCombatListener.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Listeners/ResidenceCombatListener.java
@@ -1,4 +1,4 @@
-package me.noobiedoobie.pvpmanager.listener;
+package me.NoChance.PvPManager.Listeners;
 
 import com.bekvon.bukkit.residence.api.ResidenceEnterLeaveEvent;
 import com.bekvon.bukkit.residence.api.ResidenceEventType;

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/Listeners/ResidenceCombatListener.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/Listeners/ResidenceCombatListener.java
@@ -1,0 +1,37 @@
+package me.noobiedoobie.pvpmanager.listener;
+
+import com.bekvon.bukkit.residence.api.ResidenceEnterLeaveEvent;
+import com.bekvon.bukkit.residence.api.ResidenceEventType;
+import me.noobiedoobie.pvpmanager.PvPManager;
+import me.noobiedoobie.pvpmanager.player.PlayerData;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+/**
+ * Listener to prevent players in combat from entering Residence-protected areas.
+ * Requires Residence plugin and PvPManager's PlayerData combat tracking.
+ */
+public class ResidenceCombatListener implements Listener {
+
+    private final PvPManager plugin;
+
+    public ResidenceCombatListener(PvPManager plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onResidenceEnter(ResidenceEnterLeaveEvent event) {
+        if (event.getEventType() != ResidenceEventType.ENTER) return;
+
+        Player player = Bukkit.getPlayer(event.getPlayer());
+        if (player == null) return;
+
+        PlayerData data = plugin.getPlayerHandler().get(player);
+        if (data != null && data.isInCombat()) {
+            event.setCancelled(true);
+            player.sendMessage(plugin.getMessage("cannot_enter_residence_while_in_combat"));
+        }
+    }
+}

--- a/pvpmanager/src/main/java/me/NoChance/PvPManager/PvPManager.java
+++ b/pvpmanager/src/main/java/me/NoChance/PvPManager/PvPManager.java
@@ -91,17 +91,22 @@ public class PvPManager extends JavaPlugin {
 	}
 
 	private void startListeners() {
-		if (CombatUtils.isVersionAtLeast(Settings.getMinecraftVersion(), "1.9")) {
-			registerListener(new EntityListener1_9(playerHandler));
-		}
-		entityListener = new EntityListener(playerHandler);
-		registerListener(entityListener);
-		if (CombatUtils.isVersionAtLeast(Settings.getMinecraftVersion(), "1.11.2")) {
-			registerListener(new PlayerListener1_11(playerHandler));
-		}
-		registerListener(new PlayerListener(playerHandler));
-		dependencyManager.startListeners(this);
-	}
+    if (CombatUtils.isVersionAtLeast(Settings.getMinecraftVersion(), "1.9")) {
+        registerListener(new EntityListener1_9(playerHandler));
+    }
+    entityListener = new EntityListener(playerHandler);
+    registerListener(entityListener);
+    if (CombatUtils.isVersionAtLeast(Settings.getMinecraftVersion(), "1.11.2")) {
+        registerListener(new PlayerListener1_11(playerHandler));
+    }
+    registerListener(new PlayerListener(playerHandler));
+    dependencyManager.startListeners(this);
+
+    // Register Residence listener if Residence plugin is present
+    if (getServer().getPluginManager().isPluginEnabled("Residence")) {
+        registerListener(new me.NoChance.PvPManager.Listeners.ResidenceCombatListener(playerHandler));
+    }
+}
 
 	private void registerCommands() {
 		registerCommand(getCommand("pvp"), new PvP(playerHandler));

--- a/pvpmanager/src/main/resources/locale/messages.properties
+++ b/pvpmanager/src/main/resources/locale/messages.properties
@@ -55,6 +55,7 @@ AFK_Protection = &6[&8PvPManager&6]&4 This player can't be attacked while AFK
 
 # Global Protection
 Global_Protection = &6[&8PvPManager&6]&4 PvP combat is globally disabled
+cannot_enter_residence_while_in_combat: "&cYou can't enter a residence while in combat!"
 
 # Player Kills
 Money_Reward = &2You got %m coins for killing player %p!


### PR DESCRIPTION
This pull request implements an integration with the Residence plugin to prevent players who are in combat (as tracked by PvPManager) from entering Residence-protected areas.

- Adds `ResidenceCombatListener`, which listens for Residence entry events.

- If a player is flagged as in combat, their attempt to enter a residence is cancelled and they receive a configurable message.

- The listener is only registered if the Residence plugin is detected on the server.

- This feature mirrors the existing WorldGuard integration, improving consistency across supported protection plugins.